### PR TITLE
Add public balance and reworked grpc with bi-directional stream to wallet-cli

### DIFF
--- a/utt/utt-client-api/include/utt-client-api/User.hpp
+++ b/utt/utt-client-api/include/utt-client-api/User.hpp
@@ -132,6 +132,8 @@ class User {
   /// to transfer the desired amount.
   TransferResult transfer(const std::string& userId, const std::string& pk, uint64_t amount) const;
 
+  void debugOutput() const;
+
  private:
   // Users can be created only by the top-level ClientApi functions
   friend std::unique_ptr<User> createUser(const std::string& userId,

--- a/utt/utt-client-api/src/User.cpp
+++ b/utt/utt-client-api/src/User.cpp
@@ -523,4 +523,31 @@ TransferResult User::transfer(const std::string& userId, const std::string& dest
   }
 }
 
+void User::debugOutput() const {
+  std::cout << "------ USER DEBUG OUTPUT START -------------\n";
+  if (!pImpl_->client_) {
+    std::cout << "User's libutt::api::client object not initialized!\n";
+  }
+  std::cout << "lastExecutedTxNum:" << pImpl_->lastExecutedTxNum_ << '\n';
+  std::cout << "coins: [\n";
+
+  auto dbgOutputCoin = [](const libutt::api::Coin& coin) {
+    std::cout << "type: " << (coin.getType() == libutt::api::Coin::Type::Budget ? "Budget" : "Normal") << ' ';
+    std::cout << "value: " << coin.getVal() << ' ';
+    std::cout << "expire: " << coin.getExpDate() << ' ';
+    std::cout << "null: " << coin.getNullifier() << ' ';
+    std::cout << "hasSig: " << coin.hasSig() << ' ';
+    std::cout << '\n';
+  };
+
+  for (const auto& coin : pImpl_->coins_) {
+    dbgOutputCoin(coin);
+  }
+  std::cout << "]\n";
+  std::cout << "budget coin: [\n";
+  if (pImpl_->budgetCoin_) dbgOutputCoin(*pImpl_->budgetCoin_);
+  std::cout << "]\n";
+  std::cout << "------ USER DEBUG OUTPUT END -------------\n";
+}
+
 }  // namespace utt::client

--- a/utt/wallet-cli/include/wallet.hpp
+++ b/utt/wallet-cli/include/wallet.hpp
@@ -21,15 +21,19 @@
 
 #include <utt-client-api/ClientApi.hpp>
 
+namespace WalletApi = vmware::concord::utt::wallet::api::v1;
+
 class Wallet {
  public:
-  using Connection = std::unique_ptr<vmware::concord::utt::wallet::api::v1::WalletService::Stub>;
+  using Connection = std::unique_ptr<WalletApi::WalletService::Stub>;
+  using Channel = std::unique_ptr<grpc::ClientReaderWriter<WalletApi::WalletRequest, WalletApi::WalletResponse>>;
+
   static Connection newConnection();
 
   /// [TODO-UTT] Should be performed by an admin app
   /// @brief Deploy a privacy application
   /// @return The public configuration of the deployed application
-  static std::pair<utt::Configuration, utt::PublicConfig> deployApp(Connection& conn);
+  static std::pair<utt::Configuration, utt::PublicConfig> deployApp(Channel& chan);
 
   /// [TODO-UTT] Create privacy budget locally because the system can't process budget requests yet.
   /// @brief Create a privacy budget locally for the user. This function is only for testing.
@@ -39,35 +43,35 @@ class Wallet {
 
   Wallet(std::string userId, utt::client::TestUserPKInfrastructure& pki, const utt::PublicConfig& config);
 
-  void showInfo(Connection& conn);
+  void showInfo(Channel& chan);
 
   /// @brief Request registration of the current user
-  void registerUser(Connection& conn);
+  void registerUser(Channel& chan);
 
   /// @brief Request the creation of a privacy budget. The amount of the budget is predetermined by the deployed app.
   /// This operation could be performed entirely by an administrator, but we add it in the wallet
   /// for demo purposes.
-  void createPrivacyBudget(Connection& conn);
+  void createPrivacyBudget(Channel& chan);
 
   /// @brief Requests the minting of public funds to private funds.
   /// @param amount the amount of public funds
-  void mint(Connection& conn, uint64_t amount);
+  void mint(Channel& chan, uint64_t amount);
 
   /// @brief Transfers the desired amount anonymously to the recipient
   /// @param amount The amount to transfer
   /// @param recipient The user id of the recipient
-  void transfer(Connection& conn, uint64_t amount, const std::string& recipient);
+  void transfer(Channel& chan, uint64_t amount, const std::string& recipient);
 
   /// @brief Burns the desired amount of private funds and converts them to public funds.
   /// @param amount The amount of private funds to burn.
-  void burn(Connection& conn, uint64_t amount);
+  void burn(Channel& chan, uint64_t amount);
 
   void debugOutput() const;
 
  private:
   /// @brief Sync up to the last known tx number. If the last known tx number is zero (or not provided) the
   /// last signed transaction number will be fetched from the system
-  void syncState(Connection& conn, uint64_t lastKnownTxNum = 0);
+  void syncState(Channel& chan, uint64_t lastKnownTxNum = 0);
 
   struct DummyUserStorage : public utt::client::IUserStorage {};
 

--- a/utt/wallet-cli/include/wallet.hpp
+++ b/utt/wallet-cli/include/wallet.hpp
@@ -73,4 +73,5 @@ class Wallet {
   std::string userId_;
   utt::client::TestUserPKInfrastructure& pki_;
   std::unique_ptr<utt::client::User> user_;
+  uint64_t publicBalance_ = 0;
 };

--- a/utt/wallet-cli/include/wallet.hpp
+++ b/utt/wallet-cli/include/wallet.hpp
@@ -62,6 +62,8 @@ class Wallet {
   /// @param amount The amount of private funds to burn.
   void burn(Connection& conn, uint64_t amount);
 
+  void debugOutput() const;
+
  private:
   /// @brief Sync up to the last known tx number. If the last known tx number is zero (or not provided) the
   /// last signed transaction number will be fetched from the system

--- a/utt/wallet-cli/proto/api/v1/api.proto
+++ b/utt/wallet-cli/proto/api/v1/api.proto
@@ -40,6 +40,8 @@ service WalletService {
     rpc getSignedTransaction(GetSignedTransactionRequest) returns (GetSignedTransactionResponse);
 
     rpc getTxData(GetTxDataRequest) returns (GetTxDataResponse);
+
+    rpc getPublicBalance(GetPublicBalanceRequest) returns (GetPublicBalanceResponse);
 }
 
 enum TxType {
@@ -55,7 +57,8 @@ message DeployPrivacyAppRequest {
 
 message DeployPrivacyAppResponse {
     optional string err = 1;    // Returns any error generated during deployment
-    optional string app_id = 2; // Some way to identify the deployed application
+    optional string privacy_contract_addr = 2; // Address of the deployed privacy contract
+    optional string token_contract_addr = 3; // Address of the deployed token contract
 }
 
 message RegisterUserRequest {
@@ -150,4 +153,13 @@ message GetTxDataResponse {
     optional string err = 1;
     optional uint64 tx_number = 2;
     optional bytes tx_data = 3;
+}
+
+message GetPublicBalanceRequest {
+    optional string user_id = 1;
+}
+
+message GetPublicBalanceResponse {
+    optional string err = 1;
+    optional uint64 public_balance = 2;
 }

--- a/utt/wallet-cli/proto/api/v1/api.proto
+++ b/utt/wallet-cli/proto/api/v1/api.proto
@@ -39,9 +39,9 @@ service WalletService {
     // Fetch an already signed (completed) transaction (either mint, burn or transfer).
     rpc getSignedTransaction(GetSignedTransactionRequest) returns (GetSignedTransactionResponse);
 
-    rpc getTxData(GetTxDataRequest) returns (GetTxDataResponse);
-
     rpc getPublicBalance(GetPublicBalanceRequest) returns (GetPublicBalanceResponse);
+
+    rpc walletChannel(stream WalletRequest) returns (stream WalletResponse);
 }
 
 enum TxType {
@@ -144,17 +144,6 @@ message GetSignedTransactionResponse {
     optional uint32 tx_data_size = 6;
 }
 
-message GetTxDataRequest {
-    optional uint64 tx_number = 1;
-    optional uint32 byte_offset = 2;
-}
-
-message GetTxDataResponse {
-    optional string err = 1;
-    optional uint64 tx_number = 2;
-    optional bytes tx_data = 3;
-}
-
 message GetPublicBalanceRequest {
     optional string user_id = 1;
 }
@@ -162,4 +151,37 @@ message GetPublicBalanceRequest {
 message GetPublicBalanceResponse {
     optional string err = 1;
     optional uint64 public_balance = 2;
+}
+
+message WalletRequest {
+    oneof req {
+        // init
+        DeployPrivacyAppRequest deploy = 1;
+        RegisterUserRequest register_user = 2;
+        // transact
+        TransferRequest transfer = 3;
+        MintRequest mint = 4;
+        BurnRequest burn = 5;
+        // sync
+        GetPublicBalanceRequest get_public_balance = 6;
+        GetLastAddedTxNumberRequest get_last_added_tx_number = 7;
+        GetSignedTransactionRequest get_signed_tx = 8;
+    }
+}
+
+message WalletResponse {
+    optional string err = 1;
+    oneof resp {
+        // init
+        DeployPrivacyAppResponse deploy = 2;
+        RegisterUserResponse register_user = 3;
+        // transact
+        TransferResponse transfer = 4;
+        MintResponse mint = 5;
+        BurnResponse burn = 6;
+        // sync
+        GetPublicBalanceResponse get_public_balance = 7;
+        GetLastAddedTxNumberResponse get_last_added_tx_number = 8;
+        GetSignedTransactionResponse get_signed_tx = 9;
+    }
 }

--- a/utt/wallet-cli/src/main.cpp
+++ b/utt/wallet-cli/src/main.cpp
@@ -68,6 +68,7 @@ struct CLIApp {
   Wallet::Connection conn;
   Wallet::Channel chan;
   utt::Configuration config;
+  utt::client::TestUserPKInfrastructure pki;
   std::map<std::string, Wallet> wallets;
   bool deployed = false;
 
@@ -97,7 +98,6 @@ struct CLIApp {
     auto configs = Wallet::deployApp(chan);
     config = std::move(configs.first);  // Save the full config for creating budgets locally later
 
-    utt::client::TestUserPKInfrastructure pki;
     auto testUserIds = pki.getUserIds();
     for (const auto& userId : testUserIds) {
       std::cout << "Creating test user with id '" << userId << "'\n";
@@ -112,7 +112,7 @@ struct CLIApp {
     return &it->second;
   };
 
-  void registerCmd(const std::vector<std::string>& cmdTokens) {
+  void registerUserCmd(const std::vector<std::string>& cmdTokens) {
     if (cmdTokens.size() != 2) {
       std::cout << "Usage: register <user-id>\n";
       return;
@@ -253,7 +253,7 @@ int main(int argc, char* argv[]) {
         if (cmdTokens.empty()) continue;
 
         if (cmdTokens[0] == "register") {
-          app.registerCmd(cmdTokens);
+          app.registerUserCmd(cmdTokens);
         } else if (cmdTokens[0] == "create-budget") {
           app.createBudgetCmd(cmdTokens);
         } else if (cmdTokens[0] == "show") {

--- a/utt/wallet-cli/src/wallet.cpp
+++ b/utt/wallet-cli/src/wallet.cpp
@@ -400,3 +400,5 @@ void Wallet::syncState(Connection& conn, uint64_t lastKnownTxNum) {
     }
   }
 }
+
+void Wallet::debugOutput() const { user_->debugOutput(); }

--- a/utt/wallet-cli/src/wallet.cpp
+++ b/utt/wallet-cli/src/wallet.cpp
@@ -15,15 +15,6 @@
 
 #include <iostream>
 
-namespace {
-void printStatus(const grpc::Status& status, const char* rpcName) {
-  if (status.ok())
-    std::cout << rpcName << " grpc status ok\n";
-  else
-    std::cout << rpcName << " grpc status error " << status.error_code() << ": " << status.error_message() << '\n';
-}
-}  // namespace
-
 using namespace vmware::concord::utt::wallet::api::v1;
 
 Wallet::Wallet(std::string userId, utt::client::TestUserPKInfrastructure& pki, const utt::PublicConfig& config)
@@ -53,8 +44,8 @@ Wallet::Connection Wallet::newConnection() {
   return WalletService::NewStub(chan);
 }
 
-void Wallet::showInfo(Connection& conn) {
-  syncState(conn);
+void Wallet::showInfo(Channel& chan) {
+  syncState(chan);
   std::cout << "\n--------- " << userId_ << " ---------\n";
   std::cout << "Public balance: " << publicBalance_ << '\n';
   std::cout << "Private balance: " << user_->getBalance() << '\n';
@@ -62,7 +53,7 @@ void Wallet::showInfo(Connection& conn) {
   std::cout << "Last executed tx number: " << user_->getLastExecutedTxNum() << '\n';
 }
 
-std::pair<utt::Configuration, utt::PublicConfig> Wallet::deployApp(Connection& conn) {
+std::pair<utt::Configuration, utt::PublicConfig> Wallet::deployApp(Channel& chan) {
   // Generate a privacy config for a N=4 replica system tolerating F=1 failures
   utt::client::ConfigInputParams params;
   params.validatorPublicKeys = std::vector<std::string>{4, "placeholderPublicKey"};  // N = 3 * F + 1
@@ -70,22 +61,25 @@ std::pair<utt::Configuration, utt::PublicConfig> Wallet::deployApp(Connection& c
   auto config = utt::client::generateConfig(params);
   if (config.empty()) throw std::runtime_error("Failed to generate a privacy app configuration!");
 
-  grpc::ClientContext ctx;
+  WalletRequest req;
+  req.mutable_deploy()->set_config(config.data(), config.size());
+  chan->Write(req);
 
-  DeployPrivacyAppRequest req;
-  req.set_config(config.data(), config.size());
-
-  DeployPrivacyAppResponse resp;
-  auto status = conn->deployPrivacyApp(&ctx, req, &resp);
-  printStatus(status, "deployPrivacyApp");
+  WalletResponse resp;
+  chan->Read(&resp);
+  if (!resp.has_deploy()) throw std::runtime_error("Expected deploy response from wallet service!");
+  std::cout << "response case: " << resp.resp_case() << '\n';
+  const auto& deployResp = resp.deploy();
+  std::cout << "has_privacy_contract_addr:" << deployResp.has_privacy_contract_addr() << '\n';
+  std::cout << "has_token_contract_addr:" << deployResp.has_token_contract_addr() << '\n';
 
   // Note that keeping the config around in memory is just a temp solution and should not happen in real system
-  if (resp.has_err()) throw std::runtime_error("Failed to deploy privacy app: " + resp.err());
+  if (deployResp.has_err()) throw std::runtime_error("Failed to deploy privacy app: " + resp.err());
 
   std::cout << "\nDeployed privacy application\n";
   std::cout << "-----------------------------------\n";
-  std::cout << "Privacy contract: " << resp.privacy_contract_addr() << '\n';
-  std::cout << "Token contract: " << resp.token_contract_addr() << '\n';
+  std::cout << "Privacy contract: " << deployResp.privacy_contract_addr() << '\n';
+  std::cout << "Token contract: " << deployResp.token_contract_addr() << '\n';
 
   return std::pair<utt::Configuration, utt::PublicConfig>{config, utt::client::getPublicConfig(config)};
 }
@@ -94,28 +88,29 @@ void Wallet::createPrivacyBudgetLocal(const utt::Configuration& config, uint64_t
   user_->createPrivacyBudgetLocal(config, amount);
 }
 
-void Wallet::registerUser(Connection& conn) {
+void Wallet::registerUser(Channel& chan) {
   auto userRegInput = user_->getRegistrationInput();
   if (userRegInput.empty()) throw std::runtime_error("Failed to create user registration input!");
 
-  grpc::ClientContext ctx;
+  WalletRequest req;
+  auto& registerReq = *req.mutable_register_user();
+  registerReq.set_user_id(userId_);
+  registerReq.set_input_rcm(userRegInput.data(), userRegInput.size());
+  registerReq.set_user_pk(user_->getPK());
+  chan->Write(req);
 
-  RegisterUserRequest req;
-  req.set_user_id(userId_);
-  req.set_input_rcm(userRegInput.data(), userRegInput.size());
-  req.set_user_pk(user_->getPK());
+  WalletResponse resp;
+  chan->Read(&resp);
+  if (!resp.has_register_user()) throw std::runtime_error("Expected register response from wallet service!");
+  const auto& regUser = resp.register_user();
 
-  RegisterUserResponse resp;
-  auto status = conn->registerUser(&ctx, req, &resp);
-  printStatus(status, "registerUser");
-
-  if (resp.has_err()) {
-    std::cout << "Failed to register user: " << resp.err() << '\n';
+  if (regUser.has_err()) {
+    std::cout << "Failed to register user: " << regUser.err() << '\n';
   } else {
-    utt::RegistrationSig sig = std::vector<uint8_t>(resp.signature().begin(), resp.signature().end());
+    utt::RegistrationSig sig = std::vector<uint8_t>(regUser.signature().begin(), regUser.signature().end());
     std::cout << "Got sig for registration with size: " << sig.size() << '\n';
 
-    utt::S2 s2 = std::vector<uint64_t>(resp.s2().begin(), resp.s2().end());
+    utt::S2 s2 = std::vector<uint64_t>(regUser.s2().begin(), regUser.s2().end());
     std::cout << "Got S2 for registration: [";
     for (const auto& val : s2) std::cout << val << ' ';
     std::cout << "]\n";
@@ -124,51 +119,57 @@ void Wallet::registerUser(Connection& conn) {
   }
 }
 
-void Wallet::createPrivacyBudget(Connection& conn) {
-  grpc::ClientContext ctx;
+void Wallet::createPrivacyBudget(Channel& chan) {
+  (void)chan;
+  // [TODO-UTT] Create budget is done locally, should be done by the system
+  // grpc::ClientContext ctx;
 
-  CreatePrivacyBudgetRequest req;
-  req.set_user_id(userId_);
+  // CreatePrivacyBudgetRequest req;
+  // req.set_user_id(userId_);
 
-  CreatePrivacyBudgetResponse resp;
-  conn->createPrivacyBudget(&ctx, req, &resp);
+  // CreatePrivacyBudgetResponse resp;
+  // conn->createPrivacyBudget(&ctx, req, &resp);
 
-  if (resp.has_err()) {
-    std::cout << "Failed to create privacy budget:" << resp.err() << '\n';
-  } else {
-    utt::PrivacyBudget budget = std::vector<uint8_t>(resp.budget().begin(), resp.budget().end());
-    utt::RegistrationSig sig = std::vector<uint8_t>(resp.signature().begin(), resp.signature().end());
+  // if (resp.has_err()) {
+  //   std::cout << "Failed to create privacy budget:" << resp.err() << '\n';
+  // } else {
+  //   utt::PrivacyBudget budget = std::vector<uint8_t>(resp.budget().begin(), resp.budget().end());
+  //   utt::RegistrationSig sig = std::vector<uint8_t>(resp.signature().begin(), resp.signature().end());
 
-    std::cout << "Got budget " << budget.size() << " bytes.\n";
-    std::cout << "Got budget sig " << sig.size() << " bytes.\n";
+  //   std::cout << "Got budget " << budget.size() << " bytes.\n";
+  //   std::cout << "Got budget sig " << sig.size() << " bytes.\n";
 
-    user_->updatePrivacyBudget(budget, sig);
-  }
+  //   user_->updatePrivacyBudget(budget, sig);
+  // }
 }
 
-void Wallet::mint(Connection& conn, uint64_t amount) {
+void Wallet::mint(Channel& chan, uint64_t amount) {
   auto mintTx = user_->mint(amount);
 
   grpc::ClientContext ctx;
 
-  MintRequest req;
-  req.set_user_id(userId_);
-  req.set_value(amount);
-  req.set_tx_data(mintTx.data_.data(), mintTx.data_.size());
+  WalletRequest req;
+  auto& mintReq = *req.mutable_mint();
+  mintReq.set_user_id(userId_);
+  mintReq.set_value(amount);
+  mintReq.set_tx_data(mintTx.data_.data(), mintTx.data_.size());
+  chan->Write(req);
 
-  MintResponse resp;
-  conn->mint(&ctx, req, &resp);
+  WalletResponse resp;
+  chan->Read(&resp);
+  if (!resp.has_mint()) throw std::runtime_error("Expected mint response from wallet service!");
+  const auto& mintResp = resp.mint();
 
-  if (resp.has_err()) {
-    std::cout << "Failed to mint:" << resp.err() << '\n';
+  if (mintResp.has_err()) {
+    std::cout << "Failed to mint:" << mintResp.err() << '\n';
   } else {
-    std::cout << "Successfully sent mint tx. Last added tx number:" << resp.last_added_tx_number() << '\n';
+    std::cout << "Successfully sent mint tx. Last added tx number:" << mintResp.last_added_tx_number() << '\n';
 
-    syncState(conn, resp.last_added_tx_number());
+    syncState(chan, mintResp.last_added_tx_number());
   }
 }
 
-void Wallet::transfer(Connection& conn, uint64_t amount, const std::string& recipient) {
+void Wallet::transfer(Channel& chan, uint64_t amount, const std::string& recipient) {
   if (userId_ == recipient) {
     std::cout << "Cannot transfer to self directly!\n";
     return;
@@ -191,28 +192,31 @@ void Wallet::transfer(Connection& conn, uint64_t amount, const std::string& reci
   while (true) {
     auto result = user_->transfer(recipient, pki_.getPublicKey(recipient), amount);
 
-    grpc::ClientContext ctx;
+    WalletRequest req;
+    auto& transferReq = *req.mutable_transfer();
+    transferReq.set_tx_data(result.requiredTx_.data_.data(), result.requiredTx_.data_.size());
+    transferReq.set_num_outputs(result.requiredTx_.numOutputs_);
+    chan->Write(req);
 
-    TransferRequest req;
-    req.set_tx_data(result.requiredTx_.data_.data(), result.requiredTx_.data_.size());
-    req.set_num_outputs(result.requiredTx_.numOutputs_);
+    WalletResponse resp;
+    chan->Read(&resp);
+    if (!resp.has_transfer()) throw std::runtime_error("Expected transfer response from wallet service!");
+    const auto& transferResp = resp.transfer();
 
-    TransferResponse resp;
-    conn->transfer(&ctx, req, &resp);
-
-    if (resp.has_err()) {
+    if (transferResp.has_err()) {
       std::cout << "Failed to transfer:" << resp.err() << '\n';
     } else {
-      std::cout << "Successfully sent transfer tx. Last added tx number:" << resp.last_added_tx_number() << '\n';
+      std::cout << "Successfully sent transfer tx. Last added tx number:" << transferResp.last_added_tx_number()
+                << '\n';
 
-      syncState(conn, resp.last_added_tx_number());
+      syncState(chan, transferResp.last_added_tx_number());
     }
 
     if (result.isFinal_) break;  // Done
   }
 }
 
-void Wallet::burn(Connection& conn, uint64_t amount) {
+void Wallet::burn(Channel& chan, uint64_t amount) {
   if (user_->getBalance() < amount) {
     std::cout << "Insufficient private balance!\n";
     return;
@@ -225,67 +229,73 @@ void Wallet::burn(Connection& conn, uint64_t amount) {
   while (true) {
     auto result = user_->burn(amount);
 
-    grpc::ClientContext ctx;
-
     if (result.isFinal_) {
-      BurnRequest req;
-      req.set_user_id(user_->getUserId());
-      req.set_value(amount);
-      req.set_tx_data(result.requiredTx_.data_.data(), result.requiredTx_.data_.size());
+      WalletRequest req;
+      auto& burnReq = *req.mutable_burn();
+      burnReq.set_user_id(user_->getUserId());
+      burnReq.set_value(amount);
+      burnReq.set_tx_data(result.requiredTx_.data_.data(), result.requiredTx_.data_.size());
+      chan->Write(req);
 
-      BurnResponse resp;
-      conn->burn(&ctx, req, &resp);
+      WalletResponse resp;
+      chan->Read(&resp);
+      if (!resp.has_burn()) throw std::runtime_error("Expected burn response from wallet service!");
+      const auto& burnResp = resp.transfer();
 
-      if (resp.has_err()) {
+      if (burnResp.has_err()) {
         std::cout << "Failed to do burn:" << resp.err() << '\n';
       } else {
-        std::cout << "Successfully sent burn tx. Last added tx number:" << resp.last_added_tx_number() << '\n';
+        std::cout << "Successfully sent burn tx. Last added tx number:" << burnResp.last_added_tx_number() << '\n';
 
-        syncState(conn, resp.last_added_tx_number());
+        syncState(chan, burnResp.last_added_tx_number());
       }
 
       break;  // Done
     } else {
-      TransferRequest req;
-      req.set_tx_data(result.requiredTx_.data_.data(), result.requiredTx_.data_.size());
-      req.set_num_outputs(result.requiredTx_.numOutputs_);
-      TransferResponse resp;
-      conn->transfer(&ctx, req, &resp);
+      WalletRequest req;
+      auto& transferReq = *req.mutable_transfer();
+      transferReq.set_tx_data(result.requiredTx_.data_.data(), result.requiredTx_.data_.size());
+      transferReq.set_num_outputs(result.requiredTx_.numOutputs_);
+      chan->Write(req);
 
-      if (resp.has_err()) {
+      WalletResponse resp;
+      chan->Read(&resp);
+      if (!resp.has_transfer()) throw std::runtime_error("Expected transfer response from wallet service!");
+      const auto& transferResp = resp.transfer();
+
+      if (transferResp.has_err()) {
         std::cout << "Failed to do self-transfer as part of burn:" << resp.err() << '\n';
         return;
       } else {
         std::cout << "Successfully sent self-transfer tx as part of burn. Last added tx number:"
-                  << resp.last_added_tx_number() << '\n';
+                  << transferResp.last_added_tx_number() << '\n';
 
-        syncState(conn, resp.last_added_tx_number());
+        syncState(chan, transferResp.last_added_tx_number());
       }
       // Continue with the next transaction in the burn process
     }
   }
 }
 
-void Wallet::syncState(Connection& conn, uint64_t lastKnownTxNum) {
+void Wallet::syncState(Channel& chan, uint64_t lastKnownTxNum) {
   std::cout << "Synchronizing state...\n";
 
   // Update public balance
-  while (true) {
-    grpc::ClientContext ctx;
-    GetPublicBalanceRequest req;
-    req.set_user_id(userId_);
-    GetPublicBalanceResponse resp;
-    auto status = conn->getPublicBalance(&ctx, req, &resp);
-    printStatus(status, "getPublicBalance");
+  {
+    WalletRequest req;
+    req.mutable_get_public_balance()->set_user_id(userId_);
+    chan->Write(req);
 
-    if (resp.has_err()) {
+    WalletResponse resp;
+    chan->Read(&resp);
+    if (!resp.has_get_public_balance())
+      throw std::runtime_error("Expected get public balance response from wallet service!");
+    const auto& getPubBalanceResp = resp.get_public_balance();
+
+    if (getPubBalanceResp.has_err()) {
       std::cout << "Failed to get public balance:" << resp.err() << '\n';
-      break;
-    } else if (!resp.has_public_balance()) {
-      std::cout << "retry getPublicBalance\n";
     } else {
-      publicBalance_ = resp.public_balance();
-      break;  // Done
+      publicBalance_ = getPubBalanceResp.public_balance();
     }
   }
 
@@ -293,107 +303,68 @@ void Wallet::syncState(Connection& conn, uint64_t lastKnownTxNum) {
   if (lastKnownTxNum == 0) {
     std::cout << "Last known tx number is zero (or not provided) - fetching last added tx number...\n";
 
-    grpc::ClientContext ctx;
-    GetLastAddedTxNumberRequest req;
-    GetLastAddedTxNumberResponse resp;
-    conn->getLastAddedTxNumber(&ctx, req, &resp);
+    WalletRequest req;
+    req.mutable_get_last_added_tx_number();
+    chan->Write(req);
 
-    if (resp.has_err()) {
+    WalletResponse resp;
+    chan->Read(&resp);
+    if (!resp.has_get_last_added_tx_number())
+      throw std::runtime_error("Expected get last added tx number response from wallet service!");
+    const auto& getLastAddedTxNumResp = resp.get_last_added_tx_number();
+
+    if (getLastAddedTxNumResp.has_err()) {
       std::cout << "Failed to get last added tx number:" << resp.err() << '\n';
     } else {
-      std::cout << "Got last added tx number:" << resp.tx_number() << '\n';
-      lastKnownTxNum = resp.tx_number();
+      std::cout << "Got last added tx number:" << getLastAddedTxNumResp.tx_number() << '\n';
+      lastKnownTxNum = getLastAddedTxNumResp.tx_number();
     }
   }
 
   for (uint64_t txNum = user_->getLastExecutedTxNum() + 1; txNum <= lastKnownTxNum; ++txNum) {
-    grpc::ClientContext ctx;
+    WalletRequest req;
+    req.mutable_get_signed_tx()->set_tx_number(txNum);
+    chan->Write(req);
 
-    GetSignedTransactionRequest req;
-    req.set_tx_number(txNum);
+    WalletResponse resp;
+    chan->Read(&resp);
+    if (!resp.has_get_signed_tx()) throw std::runtime_error("Expected get signed tx response from wallet service!");
+    const auto& getSignedTxResp = resp.get_signed_tx();
 
-    GetSignedTransactionResponse resp;
-    auto status = conn->getSignedTransaction(&ctx, req, &resp);
-    printStatus(status, "getSignedTransaction");
-
-    if (resp.has_err()) {
+    if (getSignedTxResp.has_err()) {
       std::cout << "Failed to get signed tx with number " << txNum << ':' << resp.err() << '\n';
       return;
     }
 
-    if (!resp.has_tx_number()) {
+    if (!getSignedTxResp.has_tx_number()) {
       std::cout << "Missing tx number in GetSignedTransactionResponse!\n";
       return;
     }
 
-    std::cout << "Got " << TxType_Name(resp.tx_type()) << " transaction.\n";
-    std::cout << "Tx num: " << resp.tx_number() << '\n';
-    std::cout << "Tx data size: " << resp.tx_data().size() << " bytes\n";
-    std::cout << "Tx data actual size: " << resp.tx_data_size() << " bytes\n";
-    std::cout << "Num Sigs: " << resp.sigs_size() << '\n';
-
     utt::Transaction tx;
-    std::copy(resp.tx_data().begin(), resp.tx_data().end(), std::back_inserter(tx.data_));
-
-    auto getTxData = [](Connection& conn, uint64_t txNumber, std::vector<uint8_t>& buff) {
-      grpc::ClientContext ctx;
-
-      GetTxDataRequest req;
-      req.set_tx_number(txNumber);
-      req.set_byte_offset((uint32_t)buff.size());
-
-      GetTxDataResponse resp;
-      conn->getTxData(&ctx, req, &resp);
-
-      if (resp.has_err()) {
-        throw std::runtime_error("getTxData: " + resp.err());
-      }
-      std::cout << "got extra data:" << resp.tx_data().size() << '\n';
-
-      std::copy(resp.tx_data().begin(), resp.tx_data().end(), std::back_inserter(buff));
-    };
-
-    // [TODO-UTT] As it seems the wallet grpc server written in node.js using grpc-js occasionally
-    // sends empty message (with missing fields) with no error either on the client or server.
-    // I have observed this mostly when fetching transactions which are a bit larger than other messages
-    // but not much - 20-50k. My initial suspicion was that the size of the proto message was at fault
-    // so I added a way to fetch the data in chunks. Each tx is cached in the wallet service and the client
-    // will fetch it sequentially in the next loop with 'getTxData'. This behavior could be a bug on part
-    // of the proto serialization in node.js or some misuse of gRPC in this client or the server. In any
-    // occasion this issue will plague the demo if not fixed properly, because syncing will fail and it
-    // needs to be retried.
-    while (true) {
-      if (tx.data_.size() < resp.tx_data_size()) {
-        std::cout << "Tx data was incomplete - fetch additional tx data...\n";
-        getTxData(conn, resp.tx_number(), tx.data_);
-      } else if (tx.data_.size() > resp.tx_data_size()) {
-        throw std::runtime_error("Got more bytes than the actual tx size!");
-      } else {  // tx size == actual size
-        break;  // Done
-      }
-    }
+    std::copy(getSignedTxResp.tx_data().begin(), getSignedTxResp.tx_data().end(), std::back_inserter(tx.data_));
 
     utt::TxOutputSigs sigs;
-    sigs.reserve((size_t)resp.sigs_size());
-    for (const auto& sig : resp.sigs()) {
+    sigs.reserve((size_t)getSignedTxResp.sigs_size());
+    for (const auto& sig : getSignedTxResp.sigs()) {
       sigs.emplace_back(std::vector<uint8_t>(sig.begin(), sig.end()));
     }
 
     // Apply transaction
-    switch (resp.tx_type()) {
+    switch (getSignedTxResp.tx_type()) {
       case TxType::MINT: {
         tx.type_ = utt::Transaction::Type::Mint;
         if (sigs.size() != 1) throw std::runtime_error("Expected single signature in mint tx!");
-        user_->updateMintTx(resp.tx_number(), tx, sigs[0]);
+        user_->updateMintTx(getSignedTxResp.tx_number(), tx, sigs[0]);
       } break;
       case TxType::TRANSFER: {
         tx.type_ = utt::Transaction::Type::Transfer;
-        user_->updateTransferTx(resp.tx_number(), tx, sigs);
+        user_->updateTransferTx(getSignedTxResp.tx_number(), tx, sigs);
       } break;
       case TxType::BURN: {
         tx.type_ = utt::Transaction::Type::Burn;
         if (!sigs.empty()) throw std::runtime_error("Expected no signatures for burn tx!");
-        user_->updateBurnTx(resp.tx_number(), tx);
+        user_->updateBurnTx(getSignedTxResp.tx_number(), tx);
       } break;
       default:
         throw std::runtime_error("Unexpected tx type!");

--- a/utt/wallet-cli/src/wallet.cpp
+++ b/utt/wallet-cli/src/wallet.cpp
@@ -102,15 +102,15 @@ void Wallet::registerUser(Channel& chan) {
   WalletResponse resp;
   chan->Read(&resp);
   if (!resp.has_register_user()) throw std::runtime_error("Expected register response from wallet service!");
-  const auto& regUser = resp.register_user();
+  const auto& regUserResp = resp.register_user();
 
-  if (regUser.has_err()) {
-    std::cout << "Failed to register user: " << regUser.err() << '\n';
+  if (regUserResp.has_err()) {
+    std::cout << "Failed to register user: " << regUserResp.err() << '\n';
   } else {
-    utt::RegistrationSig sig = std::vector<uint8_t>(regUser.signature().begin(), regUser.signature().end());
+    utt::RegistrationSig sig = std::vector<uint8_t>(regUserResp.signature().begin(), regUserResp.signature().end());
     std::cout << "Got sig for registration with size: " << sig.size() << '\n';
 
-    utt::S2 s2 = std::vector<uint64_t>(regUser.s2().begin(), regUser.s2().end());
+    utt::S2 s2 = std::vector<uint64_t>(regUserResp.s2().begin(), regUserResp.s2().end());
     std::cout << "Got S2 for registration: [";
     for (const auto& val : s2) std::cout << val << ' ';
     std::cout << "]\n";


### PR DESCRIPTION
This PR includes support for the ERC20 token contract by fetching and listing the number of tokens owned by the user as 'public balance' during sync. Also included a rework to use a bi-directional stream for grpc messaging - this avoids a previous problem where a unary grpc call may not receive a response from the grpc server because the stream is closed with an error. With a streaming rpc we can control how long the stream is open to get all messages through.